### PR TITLE
Enhance frontend layout and navigation

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import DisclaimerBanner from "../components/DisclaimerBanner";
 import Providers from "../components/Providers";
+import Navbar from "../components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,6 +30,7 @@ export default function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <Providers>
           <DisclaimerBanner />
+          <Navbar />
           {children}
         </Providers>
       </body>

--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -32,6 +32,7 @@
   flex-direction: column;
   gap: 32px;
   grid-row-start: 2;
+  align-items: center;
 }
 
 .main ol {
@@ -164,4 +165,17 @@ a.secondary {
   .logo {
     filter: invert();
   }
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+  width: 100%;
+  max-width: 1200px;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,11 +13,14 @@ export default function Home() {
   const sample = laps || [];
   return (
     <main className={styles.main}>
-      <LapTimeLine data={sample} />
-      <TyreStintBar data={sample} />
-      <StrategyGantt />
-      <PositionsWaterfall />
-      <TrackEvolution />
+      <h1 className={styles.title}>Race Insights</h1>
+      <div className={styles.grid}>
+        <LapTimeLine data={sample} />
+        <TyreStintBar data={sample} />
+        <StrategyGantt />
+        <PositionsWaterfall />
+        <TrackEvolution />
+      </div>
     </main>
   );
 }

--- a/frontend/src/components/Navbar.module.css
+++ b/frontend/src/components/Navbar.module.css
@@ -1,0 +1,53 @@
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: var(--foreground);
+  color: var(--background);
+}
+
+.logo {
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: inherit;
+}
+
+.links {
+  display: flex;
+  list-style: none;
+  gap: 1rem;
+}
+
+.links li a {
+  color: inherit;
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .toggle {
+    display: block;
+  }
+  .links {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: var(--foreground);
+    color: var(--background);
+    padding: 1rem;
+  }
+  .links.show {
+    display: flex;
+  }
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,33 @@
+'use client';
+import Link from 'next/link';
+import { useState } from 'react';
+import { Menu } from 'lucide-react';
+import styles from './Navbar.module.css';
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+  return (
+    <nav className={styles.navbar}>
+      <Link href="/" className={styles.logo}>
+        F1 Insights
+      </Link>
+      <button className={styles.toggle} onClick={() => setOpen(!open)} aria-label="Toggle navigation">
+        <Menu size={24} />
+      </button>
+      <ul className={`${styles.links} ${open ? styles.show : ''}`}>
+        <li>
+          <Link href="/">Home</Link>
+        </li>
+        <li>
+          <Link href="/drivers">Drivers</Link>
+        </li>
+        <li>
+          <Link href="/constructors">Constructors</Link>
+        </li>
+        <li>
+          <Link href="/compare">Compare</Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add responsive Navbar component
- integrate Navbar in root layout
- arrange home page charts in a grid with heading
- add styles for heading and grid

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878c1edec8c833197ada97b3401afa6