### PR TITLE
Improve backend testing and lifespan

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,46 +1,57 @@
 from fastapi import FastAPI
+from contextlib import asynccontextmanager
+
 from .database import init_db
 from .models import Event, Session, Lap
 from .fastf1_adapter import get_session
 
-app = FastAPI(title="F1 Weekend Insights")
 
-@app.on_event("startup")
-async def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     await init_db()
+    yield
 
-@app.get("/series")
-async def get_series():
-    return ["F1"]
 
-@app.get("/seasons")
-async def get_seasons(series: str = "F1"):
-    return list(range(2025, 2017, -1))
+def create_app() -> FastAPI:
+    app = FastAPI(title="F1 Weekend Insights", lifespan=lifespan)
 
-@app.get("/events/{season}")
-async def get_events(season: int):
-    return []
+    @app.get("/series")
+    async def get_series():
+        return ["F1"]
 
-@app.get("/sessions/{event_id}")
-async def get_sessions(event_id: int):
-    return []
+    @app.get("/seasons")
+    async def get_seasons(series: str = "F1"):
+        return list(range(2025, 2017, -1))
 
-@app.get("/weekend/{session_id}/laps")
-async def get_laps(session_id: int):
-    return []
+    @app.get("/events/{season}")
+    async def get_events(season: int):
+        return []
 
-@app.get("/weekend/{session_id}/stints")
-async def get_stints(session_id: int):
-    return []
+    @app.get("/sessions/{event_id}")
+    async def get_sessions(event_id: int):
+        return []
 
-@app.get("/summary/drivers")
-async def summary_drivers(season: int = None, event: int = None):
-    return []
+    @app.get("/weekend/{session_id}/laps")
+    async def get_laps(session_id: int):
+        return []
 
-@app.get("/summary/constructors")
-async def summary_constructors(season: int = None, event: int = None):
-    return []
+    @app.get("/weekend/{session_id}/stints")
+    async def get_stints(session_id: int):
+        return []
 
-@app.post("/compare")
-async def compare():
-    return {}
+    @app.get("/summary/drivers")
+    async def summary_drivers(season: int = None, event: int = None):
+        return []
+
+    @app.get("/summary/constructors")
+    async def summary_constructors(season: int = None, event: int = None):
+        return []
+
+    @app.post("/compare")
+    async def compare():
+        return {}
+
+    return app
+
+
+app = create_app()

--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -1,1 +1,4 @@
-from app.main import app
+from app.main import create_app
+
+
+app = create_app()

--- a/backend/tests/test_basic.py
+++ b/backend/tests/test_basic.py
@@ -1,7 +1,10 @@
 import pytest
-from httpx import AsyncClient
-from httpx import ASGITransport
-from app.main import app
+from httpx import AsyncClient, ASGITransport
+import app.main as main
+import app.fastf1_adapter as fastf1_adapter
+from asgi_lifespan import LifespanManager
+
+app = main.create_app()
 
 @pytest.mark.asyncio
 async def test_series():
@@ -10,3 +13,46 @@ async def test_series():
         res = await ac.get('/series')
         assert res.status_code == 200
         assert res.json() == ['F1']
+
+
+def test_get_session_cache(monkeypatch):
+    calls = []
+
+    class DummySession:
+        def load(self):
+            calls.append('load')
+
+    def fake_get_session(season, gp, session):
+        calls.append((season, gp, session))
+        return DummySession()
+
+    monkeypatch.setattr(fastf1_adapter, 'fastf1', type('m', (), {'get_session': fake_get_session}))
+
+    fastf1_adapter.get_session.cache_clear()
+
+    sess1 = fastf1_adapter.get_session(2024, 'Bahrain', 'FP1')
+    sess2 = fastf1_adapter.get_session(2024, 'Bahrain', 'FP1')
+
+    assert sess1 is sess2
+    assert calls.count('load') == 1
+    assert calls.count((2024, 'Bahrain', 'FP1')) == 1
+
+
+@pytest.mark.asyncio
+async def test_lifespan_calls_init_db(monkeypatch):
+    called = []
+
+    async def fake_init_db():
+        called.append(True)
+
+    monkeypatch.setattr(main, 'init_db', fake_init_db)
+
+    app = main.create_app()
+
+    transport = ASGITransport(app=app)
+    async with LifespanManager(app):
+        async with AsyncClient(transport=transport, base_url='http://test') as ac:
+            res = await ac.get('/series')
+            assert res.status_code == 200
+
+    assert called, 'init_db should be called during lifespan startup'


### PR DESCRIPTION
## Summary
- refactor FastAPI to use a lifespan context manager and helper `create_app`
- adjust `asgi.py` to build the application via `create_app`
- extend backend tests with FastF1 caching and lifespan startup checks

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c0f4609c833196424eb4dafdb2e4