### PR TITLE
Add Dockerfiles and update compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/__pycache__/
+**/*.pyc
+node_modules/
+frontend/node_modules/
+backend/venv/
+.git
+

--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ Development environment:
 docker-compose up --build
 ```
 
-This will start the FastAPI backend, Postgres, Redis, and Next.js frontend.
+This will build and start the FastAPI backend and Next.js frontend along with
+Postgres and Redis. The compose configuration references the Dockerfiles in the
+`backend` and `frontend` directories.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "asgi:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,20 +9,22 @@ services:
   redis:
     image: redis:7
   api:
-    build: .
-    command: uvicorn backend.asgi:app --host 0.0.0.0 --port 8000
+    build:
+      context: ./backend
+    command: uvicorn asgi:app --host 0.0.0.0 --port 8000
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db/postgres
       REDIS_URL: redis://redis:6379
     depends_on:
       - db
       - redis
+    ports:
+      - "8000:8000"
   frontend:
-    image: node:20
-    working_dir: /app
+    build: ./frontend
+    command: npm run dev
     volumes:
-      - ./frontend:/app/frontend
-    command: npm run dev --workspace frontend
+      - ./frontend:/app
     ports:
       - "3000:3000"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add `.dockerignore`
- add Dockerfiles for backend and frontend
- update compose file to build each service
- document compose setup in README

## Testing
- `pytest -q backend/tests`
- `npm --prefix frontend install`
- `npm --prefix frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878d3de97c483318a67349cbf87c5ec