### PR TITLE
Add launch helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ docker-compose up --build
 This will build and start the FastAPI backend and Next.js frontend along with
 Postgres and Redis. The compose configuration references the Dockerfiles in the
 `backend` and `frontend` directories.
+
+For convenience, you can start the stack using `run-stack.bat` on Windows or `./run-stack.sh` on Linux/macOS.
+These scripts build and start the containers, wait a few seconds and then open http://localhost:3000 in your browser.

--- a/run-stack.bat
+++ b/run-stack.bat
@@ -1,0 +1,46 @@
+@echo off
+rem ============================================================
+rem  F1-Insights  – one-click local launcher (Windows .bat)
+rem  Place this file in the repo root (same level as compose.yml)
+rem ============================================================
+
+setlocal ENABLEDELAYEDEXPANSION
+
+rem ── 1. Check Docker is running ───────────────────────────────
+docker info >nul 2>&1
+if errorlevel 1 (
+    echo.
+    echo  ❌  Docker Desktop does not appear to be running.
+    echo      Please start Docker and try again.
+    pause
+    exit /b 1
+)
+
+rem ── 2. Build + start the full stack ──────────────────────────
+echo.
+echo  🚀  Building and starting containers …
+docker compose up -d --build
+if errorlevel 1 (
+    echo  ❌  docker compose failed.
+    pause
+    exit /b 1
+)
+
+rem ── 3. Give services a moment to boot ────────────────────────
+echo.
+echo  ⏳  Waiting 10 seconds for services to come online …
+timeout /t 10 >nul
+
+rem ── 4. Launch browser at front-end URL ───────────────────────
+echo.
+echo  🌐  Opening http://localhost:3000
+start "" "http://localhost:3000"
+
+rem ── 5. Helpful tips ──────────────────────────────────────────
+echo.
+echo  ✔️  Stack is up!
+echo  View logs:        docker compose logs -f
+echo  Stop everything:  docker compose down
+echo.
+pause
+endlocal

--- a/run-stack.sh
+++ b/run-stack.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo -e "\n🚀  Building & starting Docker containers…"
+docker compose up -d --build
+
+echo -e "\n⏳  Waiting a few seconds…"
+sleep 10
+
+echo -e "\n🌐  Opening browser at http://localhost:3000"
+if command -v xdg-open >/dev/null 2>&1; then
+  xdg-open http://localhost:3000
+elif command -v open >/dev/null 2>&1; then   # macOS
+  open http://localhost:3000
+else
+  echo "Open your browser and go to http://localhost:3000"
+fi


### PR DESCRIPTION
## Summary
- add `run-stack.bat` for Windows users
- add `run-stack.sh` for macOS/Linux
- document one-click scripts in the README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm install`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6878fb994c3c83318558122335264877