### PR TITLE
Add 'use client' directive to home page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import dynamic from 'next/dynamic';
 import styles from './page.module.css';
 import { useApi } from '../lib/useApi';


### PR DESCRIPTION
## Summary
- fix Next build by marking `page.tsx` as a client component

## Testing
- `docker compose build frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790417b22083319f576fce9bf9feb3