### PR TITLE
Relax ESLint for Next.js build

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- update next configuration to ignore ESLint errors during builds

## Testing
- `npm ci`
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68790ea343b08331b52cedd950657d46