### PR TITLE
Fix React Query pages

### DIFF
--- a/frontend/src/app/compare/page.tsx
+++ b/frontend/src/app/compare/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useApi } from '../../lib/useApi';
 
 export default function ComparePage() {

--- a/frontend/src/app/constructors/page.tsx
+++ b/frontend/src/app/constructors/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useApi } from '../../lib/useApi';
 
 export default function ConstructorsPage() {

--- a/frontend/src/app/drivers/page.tsx
+++ b/frontend/src/app/drivers/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useApi } from '../../lib/useApi';
 
 export default function DriversPage() {


### PR DESCRIPTION
## Summary
- make compare, constructors, and drivers pages client components so React Query runs in Next.js 15

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests`
- `npm install` in frontend
- `npm test` in frontend
- `npm run build` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68791196f8588331b6f2a6a3481b0227