### PR TITLE
Improve chart layout

### DIFF
--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -179,3 +179,16 @@ a.secondary {
   width: 100%;
   max-width: 1200px;
 }
+
+.chartCard {
+  background: var(--gray-alpha-100);
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+  .chartCard {
+    box-shadow: 0 2px 4px rgba(255, 255, 255, 0.05);
+  }
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -17,11 +17,21 @@ export default function Home() {
     <main className={styles.main}>
       <h1 className={styles.title}>Race Insights</h1>
       <div className={styles.grid}>
-        <LapTimeLine data={sample} />
-        <TyreStintBar data={sample} />
-        <StrategyGantt />
-        <PositionsWaterfall />
-        <TrackEvolution />
+        <div className={styles.chartCard}>
+          <LapTimeLine data={sample} />
+        </div>
+        <div className={styles.chartCard}>
+          <TyreStintBar data={sample} />
+        </div>
+        <div className={styles.chartCard}>
+          <StrategyGantt />
+        </div>
+        <div className={styles.chartCard}>
+          <PositionsWaterfall />
+        </div>
+        <div className={styles.chartCard}>
+          <TrackEvolution />
+        </div>
       </div>
     </main>
   );

--- a/frontend/src/components/charts/LapTimeLine.tsx
+++ b/frontend/src/components/charts/LapTimeLine.tsx
@@ -1,13 +1,15 @@
 'use client';
-import { LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
 
 export default function LapTimeLine({ data }: { data: any[] }) {
   return (
-    <LineChart width={400} height={200} data={data}>
-      <XAxis dataKey="lap" />
-      <YAxis />
-      <Tooltip />
-      <Line type="monotone" dataKey="time" stroke="#8884d8" />
-    </LineChart>
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <XAxis dataKey="lap" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="time" stroke="#8884d8" />
+      </LineChart>
+    </ResponsiveContainer>
   );
 }

--- a/frontend/src/components/charts/TyreStintBar.tsx
+++ b/frontend/src/components/charts/TyreStintBar.tsx
@@ -1,13 +1,15 @@
 'use client';
-import { BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
 
 export default function TyreStintBar({ data }: { data: any[] }) {
   return (
-    <BarChart width={400} height={200} data={data}>
-      <XAxis dataKey="stint" />
-      <YAxis />
-      <Tooltip />
-      <Bar dataKey="laps" fill="#82ca9d" />
-    </BarChart>
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <XAxis dataKey="stint" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="laps" fill="#82ca9d" />
+      </BarChart>
+    </ResponsiveContainer>
   );
 }


### PR DESCRIPTION
## Summary
- make chart components responsive using `ResponsiveContainer`
- add card styling around charts
- wrap charts in new card containers on home page

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687911e973e0833199df321a4632c43b