### PR TITLE
Add accent color variable and apply

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,6 +1,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --accent: #FF1E00;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -170,6 +170,8 @@ a.secondary {
 .title {
   font-size: 2rem;
   font-weight: 600;
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 4px;
 }
 
 .grid {

--- a/frontend/src/components/Navbar.module.css
+++ b/frontend/src/components/Navbar.module.css
@@ -13,6 +13,7 @@
 .logo {
   font-weight: 600;
   font-size: 1.25rem;
+  color: var(--accent);
 }
 
 .toggle {
@@ -31,6 +32,10 @@
 .links li a {
   color: inherit;
   text-decoration: none;
+}
+
+.links li a:hover {
+  color: var(--accent);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add `--accent` variable in global CSS
- highlight navigation and title using the accent color

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6879eaa941908331b0730b639400b437