### PR TITLE
Implement ConstructorCard component

### DIFF
--- a/frontend/src/app/constructors/constructors.module.css
+++ b/frontend/src/app/constructors/constructors.module.css
@@ -1,0 +1,8 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+  width: 100%;
+  max-width: 1200px;
+  margin-top: 16px;
+}

--- a/frontend/src/app/constructors/page.tsx
+++ b/frontend/src/app/constructors/page.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import { useApi } from '../../lib/useApi';
+import ConstructorCard from '../../components/ConstructorCard';
+import styles from './constructors.module.css';
 
 export default function ConstructorsPage() {
   const { data } = useApi<any[]>('constructors', '/api/constructors');
   return (
     <div>
       <h1>Constructors</h1>
-      <pre>{JSON.stringify(data, null, 2)}</pre>
+      <div className={styles.grid}>
+        {data?.map((c: any) => (
+          <ConstructorCard key={c.constructorId ?? c.name} constructor={c} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ConstructorCard.module.css
+++ b/frontend/src/components/ConstructorCard.module.css
@@ -1,0 +1,29 @@
+.card {
+  background: var(--gray-alpha-100);
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card {
+    box-shadow: 0 2px 4px rgba(255, 255, 255, 0.05);
+  }
+}
+
+.name {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.nationality {
+  color: #666;
+}
+
+.points {
+  margin-top: 4px;
+  font-weight: 500;
+}

--- a/frontend/src/components/ConstructorCard.tsx
+++ b/frontend/src/components/ConstructorCard.tsx
@@ -1,0 +1,22 @@
+import styles from './ConstructorCard.module.css';
+
+export interface Constructor {
+  constructorId?: string | number;
+  name: string;
+  nationality?: string;
+  points?: number;
+}
+
+export default function ConstructorCard({ constructor }: { constructor: Constructor }) {
+  return (
+    <div className={styles.card}>
+      <h2 className={styles.name}>{constructor.name}</h2>
+      {constructor.nationality && (
+        <p className={styles.nationality}>{constructor.nationality}</p>
+      )}
+      {constructor.points !== undefined && (
+        <p className={styles.points}>{constructor.points} pts</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show constructor data using a new `ConstructorCard` component
- display constructor cards in a responsive grid on the constructors page

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879eac4afc48331ad5721786bc0f07d