### PR TITLE
Add driver comparison feature

### DIFF
--- a/frontend/src/app/compare/compare.module.css
+++ b/frontend/src/app/compare/compare.module.css
@@ -1,0 +1,13 @@
+.form {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.select {
+  flex: 1;
+}
+
+.button {
+  padding: 8px 16px;
+}

--- a/frontend/src/app/compare/page.tsx
+++ b/frontend/src/app/compare/page.tsx
@@ -1,13 +1,58 @@
 'use client';
 
+import { useState } from 'react';
 import { useApi } from '../../lib/useApi';
+import ComparisonTable from '../../components/ComparisonTable';
+import styles from './compare.module.css';
 
 export default function ComparePage() {
-  const { data } = useApi<any>('compare', '/api/compare');
+  const { data: drivers } = useApi<any[]>('drivers', '/api/drivers');
+  const [driver1, setDriver1] = useState('');
+  const [driver2, setDriver2] = useState('');
+  const [path, setPath] = useState('');
+  const { data: comparison } = useApi<any[]>('comparison', path, {
+    enabled: Boolean(path),
+  });
+
+  const handleCompare = () => {
+    if (driver1 && driver2) {
+      setPath(`/api/compare?driver1=${driver1}&driver2=${driver2}`);
+    }
+  };
+
   return (
     <div>
-      <h1>Compare</h1>
-      <pre>{JSON.stringify(data, null, 2)}</pre>
+      <h1>Compare Drivers</h1>
+      <div className={styles.form}>
+        <select
+          className={styles.select}
+          value={driver1}
+          onChange={(e) => setDriver1(e.target.value)}
+        >
+          <option value="">Select Driver 1</option>
+          {drivers?.map((d: any) => (
+            <option key={d.id} value={d.id}>
+              {d.name}
+            </option>
+          ))}
+        </select>
+        <select
+          className={styles.select}
+          value={driver2}
+          onChange={(e) => setDriver2(e.target.value)}
+        >
+          <option value="">Select Driver 2</option>
+          {drivers?.map((d: any) => (
+            <option key={d.id} value={d.id}>
+              {d.name}
+            </option>
+          ))}
+        </select>
+        <button className={styles.button} onClick={handleCompare}>
+          Compare
+        </button>
+      </div>
+      <ComparisonTable data={comparison || []} />
     </div>
   );
 }

--- a/frontend/src/components/ComparisonTable.module.css
+++ b/frontend/src/components/ComparisonTable.module.css
@@ -1,0 +1,16 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+
+.table th {
+  background: var(--foreground);
+  color: var(--background);
+}

--- a/frontend/src/components/ComparisonTable.tsx
+++ b/frontend/src/components/ComparisonTable.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import styles from './ComparisonTable.module.css';
+
+interface Row {
+  label: string;
+  driver1: string | number;
+  driver2: string | number;
+}
+
+export default function ComparisonTable({ data }: { data: Row[] }) {
+  if (!data || data.length === 0) return null;
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Metric</th>
+          <th>Driver 1</th>
+          <th>Driver 2</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, i) => (
+          <tr key={i}>
+            <td>{row.label}</td>
+            <td>{row.driver1}</td>
+            <td>{row.driver2}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch drivers list and let users select two drivers
- call `/api/compare` on demand and show results in a table
- style compare form and table with CSS modules

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6879eac52ec883319f75da0df16d7a4b