### PR TITLE
Remove version field from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: postgres:16


### PR DESCRIPTION
## Summary
- remove the deprecated `version:` line from `docker-compose.yml`

## Testing
- `docker compose config`
- `docker compose up --dry-run` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687a04920338833183a35f488e5ecbfd