### PR TITLE
Fix Dockerfile build failure handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json* ./
 RUN npm install
 COPY frontend ./frontend
-RUN npm run build --workspace frontend || true
+RUN npm run build --workspace frontend
 
 FROM base AS final
 COPY --from=frontend /app/frontend/.next ./frontend/.next


### PR DESCRIPTION
## Summary
- remove `|| true` from the root Dockerfile so the frontend build fails if `npm run build` fails

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm install` in `frontend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687a049257f88331be5b2c5fffd1ee21