### PR TITLE
Fix useApi options typing

### DIFF
--- a/frontend/src/lib/useApi.ts
+++ b/frontend/src/lib/useApi.ts
@@ -1,7 +1,11 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
-export function useApi<T>(key: string, path: string, options?: UseQueryOptions<T>) {
-  return useQuery<T>({
+export function useApi<T>(
+  key: string,
+  path: string,
+  options?: Omit<UseQueryOptions<T, Error, T, [string, string]>, 'queryKey' | 'queryFn'>,
+) {
+  return useQuery<T, Error, T, [string, string]>({
     queryKey: [key, path],
     queryFn: async () => {
       const res = await fetch(path);


### PR DESCRIPTION
## Summary
- relax `useApi` options to omit `queryKey` and `queryFn`

## Testing
- `npm run build` in `frontend`
- `npm test` in `frontend`
- ❌ `docker build` frontend image (daemon unavailable)


------
https://chatgpt.com/codex/tasks/task_e_687a049276e0833180069fd9109e2433