### PR TITLE
Add driver summary dropdown

### DIFF
--- a/frontend/src/app/drivers/drivers.module.css
+++ b/frontend/src/app/drivers/drivers.module.css
@@ -18,3 +18,12 @@
   width: 100%;
   max-width: 1200px;
 }
+
+.form {
+  display: flex;
+  gap: 8px;
+}
+
+.select {
+  min-width: 200px;
+}

--- a/frontend/src/app/drivers/page.tsx
+++ b/frontend/src/app/drivers/page.tsx
@@ -1,15 +1,55 @@
 'use client';
 
+import { useState } from 'react';
 import DriverCard from '../../components/DriverCard';
+import DriverSummaryCards from '../../components/DriverSummaryCards';
 import { useApi } from '../../lib/useApi';
 import styles from './drivers.module.css';
 
 export default function DriversPage() {
-  const { data } = useApi<any[]>('drivers', '/api/drivers');
-  const drivers = data || [];
+  const { data: driversData } = useApi<any[]>('drivers', '/api/drivers');
+  const [selected, setSelected] = useState('');
+
+  const drivers = (driversData || [])
+    .slice()
+    .sort((a, b) => {
+      const nameA =
+        a.name ||
+        a.fullName ||
+        `${a.givenName ?? ''} ${a.familyName ?? ''}`.trim();
+      const nameB =
+        b.name ||
+        b.fullName ||
+        `${b.givenName ?? ''} ${b.familyName ?? ''}`.trim();
+      return nameA.localeCompare(nameB);
+    });
+
+  const { data: summary } = useApi<any[]>(
+    'driver-summary',
+    selected ? `/api/driver/${selected}/summary` : '',
+    { enabled: Boolean(selected) }
+  );
+
+  const getDriverName = (d: any) =>
+    d.name || d.fullName || `${d.givenName ?? ''} ${d.familyName ?? ''}`.trim();
   return (
     <main className={styles.main}>
       <h1 className={styles.title}>Drivers</h1>
+      <div className={styles.form}>
+        <select
+          className={styles.select}
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+        >
+          <option value="">Select Driver</option>
+          {drivers.map((d) => (
+            <option key={d.id} value={d.id}>
+              {getDriverName(d)}
+            </option>
+          ))}
+        </select>
+      </div>
+      <DriverSummaryCards summary={summary || []} />
       <div className={styles.grid}>
         {drivers.map((driver, i) => (
           <DriverCard

--- a/frontend/src/components/DriverSummaryCards.module.css
+++ b/frontend/src/components/DriverSummaryCards.module.css
@@ -1,0 +1,31 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  width: 100%;
+  max-width: 1200px;
+}
+
+.card {
+  background: var(--gray-alpha-100, #f5f5f5);
+  padding: 16px;
+  border-radius: 8px;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.value {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.label {
+  color: #666;
+  font-size: 0.875rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card {
+    box-shadow: 0 2px 4px rgba(255, 255, 255, 0.05);
+  }
+}

--- a/frontend/src/components/DriverSummaryCards.tsx
+++ b/frontend/src/components/DriverSummaryCards.tsx
@@ -1,0 +1,24 @@
+import styles from './DriverSummaryCards.module.css';
+
+interface SummaryItem {
+  label: string;
+  value: string | number;
+}
+
+export default function DriverSummaryCards({
+  summary,
+}: {
+  summary: SummaryItem[];
+}) {
+  if (!summary || summary.length === 0) return null;
+  return (
+    <div className={styles.grid}>
+      {summary.map((item, i) => (
+        <div key={i} className={styles.card}>
+          <div className={styles.value}>{item.value}</div>
+          <div className={styles.label}>{item.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show a dropdown of drivers on the Drivers page
- sort driver names ascending
- fetch summary data for a selected driver and render `<DriverSummaryCards />`
- add new `DriverSummaryCards` component and styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a1614c2fc8331afdb07dd75048080