### PR TITLE
Add driver seasons table with expandable rows

### DIFF
--- a/frontend/src/app/drivers/[id]/page.tsx
+++ b/frontend/src/app/drivers/[id]/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useState } from 'react';
+import { useApi } from '../../../lib/useApi';
+import DriverCard from '../../../components/DriverCard';
+import DriverSeasonsTable from '../../../components/DriverSeasonsTable';
+
+export default function DriverPage({ params }: { params: { id: string } }) {
+  const id = params.id;
+  const { data: driver } = useApi<any>(`driver-${id}`, `/api/driver/${id}`);
+  const { data: seasons } = useApi<any[]>(`driver-${id}-seasons`, `/api/driver/${id}/seasons`);
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const summary = selected && seasons ? seasons.find((s) => s.year === selected) : driver;
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      {summary && <DriverCard driver={summary} />}
+      <DriverSeasonsTable driverId={id} onSeasonSelect={setSelected} />
+    </main>
+  );
+}

--- a/frontend/src/app/drivers/page.tsx
+++ b/frontend/src/app/drivers/page.tsx
@@ -2,6 +2,7 @@
 
 import DriverCard from '../../components/DriverCard';
 import { useApi } from '../../lib/useApi';
+import Link from 'next/link';
 import styles from './drivers.module.css';
 
 export default function DriversPage() {
@@ -12,10 +13,12 @@ export default function DriversPage() {
       <h1 className={styles.title}>Drivers</h1>
       <div className={styles.grid}>
         {drivers.map((driver, i) => (
-          <DriverCard
+          <Link
             key={driver.id ?? driver.code ?? driver.name ?? i}
-            driver={driver}
-          />
+            href={`/drivers/${driver.id ?? driver.code ?? i}`}
+          >
+            <DriverCard driver={driver} />
+          </Link>
         ))}
       </div>
     </main>

--- a/frontend/src/components/DriverSeasonsTable.tsx
+++ b/frontend/src/components/DriverSeasonsTable.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import { useApi } from '../lib/useApi';
+
+interface Season {
+  year: number;
+  [key: string]: any;
+}
+
+interface Race {
+  id?: string | number;
+  name?: string;
+  [key: string]: any;
+}
+
+function SeasonRaces({ driverId, year }: { driverId: string | number; year: number }) {
+  const { data: races } = useApi<Race[]>(`driver-${driverId}-${year}-races`, `/api/driver/${driverId}/season/${year}/races`);
+  if (!races) {
+    return (
+      <tr>
+        <td colSpan={3}>Loading...</td>
+      </tr>
+    );
+  }
+  return (
+    <>
+      {races.map((r) => (
+        <tr key={r.id ?? r.name}>
+          <td style={{ paddingLeft: '2rem' }} colSpan={3}>
+            {r.name}
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+export default function DriverSeasonsTable({
+  driverId,
+  onSeasonSelect,
+}: {
+  driverId: string | number;
+  onSeasonSelect?: (season: number) => void;
+}) {
+  const { data: seasons } = useApi<Season[]>(`driver-${driverId}-seasons`, `/api/driver/${driverId}/seasons`);
+  const [expanded, setExpanded] = useState<Record<number, boolean>>({});
+
+  const toggle = (year: number) => {
+    setExpanded((prev) => ({ ...prev, [year]: !prev[year] }));
+    onSeasonSelect?.(year);
+  };
+
+  if (!seasons) return null;
+
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr>
+          <th style={{ border: '1px solid #ccc', padding: '8px', textAlign: 'left' }}>Year</th>
+          <th style={{ border: '1px solid #ccc', padding: '8px', textAlign: 'left' }}>Team</th>
+          <th style={{ border: '1px solid #ccc', padding: '8px', textAlign: 'left' }}>Points</th>
+        </tr>
+      </thead>
+      <tbody>
+        {seasons.map((season) => (
+          <>
+            <tr
+              key={season.year}
+              style={{ cursor: 'pointer' }}
+              onClick={() => toggle(season.year)}
+            >
+              <td style={{ border: '1px solid #ccc', padding: '8px' }}>{season.year}</td>
+              <td style={{ border: '1px solid #ccc', padding: '8px' }}>{season.team ?? season.constructor}</td>
+              <td style={{ border: '1px solid #ccc', padding: '8px' }}>{season.points ?? ''}</td>
+            </tr>
+            {expanded[season.year] && (
+              <SeasonRaces key={`races-${season.year}`} driverId={driverId} year={season.year} />
+            )}
+          </>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- add `DriverSeasonsTable` for expandable season rows
- create dynamic driver page that filters summary card by selected season
- link each driver card to the new page

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a16177694833194e899e30c0e9121