### PR TITLE
Add TopRaceResults component

### DIFF
--- a/frontend/src/app/drivers/drivers.module.css
+++ b/frontend/src/app/drivers/drivers.module.css
@@ -18,3 +18,7 @@
   width: 100%;
   max-width: 1200px;
 }
+
+.select {
+  max-width: 300px;
+}

--- a/frontend/src/app/drivers/page.tsx
+++ b/frontend/src/app/drivers/page.tsx
@@ -1,15 +1,36 @@
 'use client';
 
+import { useState } from 'react';
 import DriverCard from '../../components/DriverCard';
+import TopRaceResults from '../../components/TopRaceResults';
 import { useApi } from '../../lib/useApi';
 import styles from './drivers.module.css';
 
 export default function DriversPage() {
   const { data } = useApi<any[]>('drivers', '/api/drivers');
   const drivers = data || [];
+  const [selected, setSelected] = useState('');
   return (
     <main className={styles.main}>
       <h1 className={styles.title}>Drivers</h1>
+      <select
+        className={styles.select}
+        value={selected}
+        onChange={(e) => setSelected(e.target.value)}
+      >
+        <option value="">Select Driver</option>
+        {drivers.map((d) => {
+          const name =
+            d.name ||
+            d.fullName ||
+            `${d.givenName ?? ''} ${d.familyName ?? ''}`.trim();
+          return (
+            <option key={d.id ?? d.code ?? name} value={d.id}>
+              {name}
+            </option>
+          );
+        })}
+      </select>
       <div className={styles.grid}>
         {drivers.map((driver, i) => (
           <DriverCard
@@ -18,6 +39,7 @@ export default function DriversPage() {
           />
         ))}
       </div>
+      {selected && <TopRaceResults driverId={selected} />}
     </main>
   );
 }

--- a/frontend/src/components/TopRaceResults.module.css
+++ b/frontend/src/components/TopRaceResults.module.css
@@ -1,0 +1,38 @@
+.row {
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  overflow-x: auto;
+}
+
+.card {
+  background: var(--gray-alpha-100);
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  min-width: 160px;
+  flex: 0 0 auto;
+  gap: 4px;
+}
+
+.metric {
+  font-weight: 600;
+}
+
+.value {
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.race {
+  font-size: 0.875rem;
+  color: #666;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card {
+    box-shadow: 0 2px 4px rgba(255, 255, 255, 0.05);
+  }
+}

--- a/frontend/src/components/TopRaceResults.tsx
+++ b/frontend/src/components/TopRaceResults.tsx
@@ -1,0 +1,38 @@
+import { useApi } from '../lib/useApi';
+import styles from './TopRaceResults.module.css';
+
+interface ResultItem {
+  metric: string;
+  value?: string | number;
+  race?: string;
+  [key: string]: any;
+}
+
+export default function TopRaceResults({
+  driverId,
+}: {
+  driverId: string | number;
+}) {
+  const { data } = useApi<ResultItem[]>(
+    `top-results-${driverId}`,
+    `/api/driver/${driverId}/top-results`,
+    { enabled: Boolean(driverId) }
+  );
+  const results = data || [];
+
+  if (!results.length) return null;
+
+  return (
+    <div className={styles.row}>
+      {results.map((res, i) => (
+        <div key={i} className={styles.card}>
+          <h3 className={styles.metric}>{res.metric}</h3>
+          {res.value !== undefined && (
+            <p className={styles.value}>{res.value}</p>
+          )}
+          {res.race && <p className={styles.race}>{res.race}</p>}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new TopRaceResults component
- update drivers page to fetch driver-specific top race results
- style driver select and new results row

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a161a12f083319f3909995266c244