### PR TITLE
Add API base URL handling

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+`NEXT_PUBLIC_API_BASE_URL` - Base URL of the backend API. If set, requests made
+with `useApi` will be prefixed with this value and Next.js will rewrite any
+`/api/*` requests to this backend during development and production.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,6 +4,16 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  async rewrites() {
+    const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!baseUrl) return [];
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${baseUrl}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/lib/useApi.ts
+++ b/frontend/src/lib/useApi.ts
@@ -8,7 +8,9 @@ export function useApi<T>(
   return useQuery<T, Error, T, [string, string]>({
     queryKey: [key, path],
     queryFn: async () => {
-      const res = await fetch(path);
+      const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+      const url = baseUrl ? new URL(path, baseUrl).toString() : path;
+      const res = await fetch(url);
       if (!res.ok) throw new Error(res.statusText);
       return res.json() as Promise<T>;
     },


### PR DESCRIPTION
## Summary
- support custom API base URL in `useApi`
- proxy `/api/*` endpoints with Next.js rewrites
- document `NEXT_PUBLIC_API_BASE_URL`

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a162513d4833189fa468171e94592