### PR TITLE
Add comparison page tests

### DIFF
--- a/frontend/__tests__/compare-page.test.js
+++ b/frontend/__tests__/compare-page.test.js
@@ -1,0 +1,77 @@
+beforeAll(() => { global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }; });
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ComparePage from '../src/app/compare/page';
+
+function setupFetch({ drivers = [], comparison = [] }) {
+  global.fetch = jest.fn((url) => {
+    if (url === '/api/drivers') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(drivers),
+      });
+    }
+    if (url.startsWith('/api/compare')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(comparison),
+      });
+    }
+    return Promise.reject(new Error('Unknown URL'));
+  });
+}
+
+function renderPage() {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <ComparePage />
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('driver dropdown alphabetical ordering', async () => {
+  setupFetch({
+    drivers: [
+      { id: '2', name: 'Verstappen' },
+      { id: '1', name: 'Alonso' },
+      { id: '3', name: 'Hamilton' },
+    ],
+  });
+  renderPage();
+  await screen.findAllByRole('option', { name: 'Alonso' });
+  const selects = screen.getAllByRole('combobox');
+  const opts1 = within(selects[0]).getAllByRole('option').map((o) => o.textContent);
+  const opts2 = within(selects[1]).getAllByRole('option').map((o) => o.textContent);
+  expect(opts1).toEqual(['Select Driver 1', 'Alonso', 'Hamilton', 'Verstappen']);
+  expect(opts2).toEqual(['Select Driver 2', 'Alonso', 'Hamilton', 'Verstappen']);
+});
+
+test('charts and tables appear only after a selection', async () => {
+  setupFetch({
+    drivers: [
+      { id: '1', name: 'Alonso' },
+      { id: '2', name: 'Verstappen' },
+    ],
+    comparison: [{ lap: 1, time: 90 }],
+  });
+  renderPage();
+  await screen.findAllByRole('option', { name: 'Alonso' });
+
+  expect(screen.queryByRole('table')).toBeNull();
+  expect(document.querySelector('.recharts-responsive-container')).toBeNull();
+
+  const selects = screen.getAllByRole('combobox');
+  fireEvent.change(selects[0], { target: { value: '1' } });
+  fireEvent.change(selects[1], { target: { value: '2' } });
+  fireEvent.click(screen.getByRole('button', { name: /compare/i }));
+
+  await screen.findByRole('table');
+  expect(document.querySelector('.recharts-responsive-container')).toBeInTheDocument();
+});

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['next/babel'],
+};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.4.1",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.4",
         "jest-environment-jsdom": "^30.0.4",
         "typescript": "^5"
@@ -5738,6 +5739,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5901,6 +5909,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ignore": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.4.1",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^30.0.4",
     "typescript": "^5"

--- a/frontend/src/app/compare/page.tsx
+++ b/frontend/src/app/compare/page.tsx
@@ -3,10 +3,16 @@
 import { useState } from 'react';
 import { useApi } from '../../lib/useApi';
 import ComparisonTable from '../../components/ComparisonTable';
+import LapTimeLine from '../../components/charts/LapTimeLine';
 import styles from './compare.module.css';
 
 export default function ComparePage() {
   const { data: drivers } = useApi<any[]>('drivers', '/api/drivers');
+  const sortedDrivers = (drivers || []).slice().sort((a, b) => {
+    const nameA = (a.name ?? '').toLowerCase();
+    const nameB = (b.name ?? '').toLowerCase();
+    return nameA.localeCompare(nameB);
+  });
   const [driver1, setDriver1] = useState('');
   const [driver2, setDriver2] = useState('');
   const [path, setPath] = useState('');
@@ -30,7 +36,7 @@ export default function ComparePage() {
           onChange={(e) => setDriver1(e.target.value)}
         >
           <option value="">Select Driver 1</option>
-          {drivers?.map((d: any) => (
+          {sortedDrivers.map((d: any) => (
             <option key={d.id} value={d.id}>
               {d.name}
             </option>
@@ -42,7 +48,7 @@ export default function ComparePage() {
           onChange={(e) => setDriver2(e.target.value)}
         >
           <option value="">Select Driver 2</option>
-          {drivers?.map((d: any) => (
+          {sortedDrivers.map((d: any) => (
             <option key={d.id} value={d.id}>
               {d.name}
             </option>
@@ -52,7 +58,12 @@ export default function ComparePage() {
           Compare
         </button>
       </div>
-      <ComparisonTable data={comparison || []} />
+      {comparison && comparison.length > 0 && (
+        <>
+          <ComparisonTable data={comparison} />
+          <LapTimeLine data={comparison} />
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/charts/LapTimeLine.tsx
+++ b/frontend/src/components/charts/LapTimeLine.tsx
@@ -3,7 +3,7 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'rec
 
 export default function LapTimeLine({ data }: { data: any[] }) {
   return (
-    <ResponsiveContainer width="100%" height={300}>
+    <ResponsiveContainer width="100%" height={300} data-testid="lap-chart">
       <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
         <XAxis dataKey="lap" />
         <YAxis />


### PR DESCRIPTION
## Summary
- configure babel and jest for React components
- sort drivers alphabetically in the comparison page
- show charts and table only after a driver selection
- expose LapTimeLine for testing
- add Jest tests for dropdown ordering and conditional display

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a16240e408331abca6c29ca4b7a19