### PR TITLE
Add drivers proxy test

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from contextlib import asynccontextmanager
+import httpx
 
 from .database import init_db
 from .models import Event, Session, Lap
@@ -50,6 +51,17 @@ def create_app() -> FastAPI:
     @app.post("/compare")
     async def compare():
         return {}
+
+    @app.api_route("/ergast/{path:path}", methods=["GET"])
+    async def ergast_proxy(path: str, request: Request):
+        url = f"https://ergast.com/api/{path}"
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=dict(request.query_params))
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            media_type=resp.headers.get("content-type", "application/json"),
+        )
 
     return app
 

--- a/backend/tests/test_drivers_proxy.py
+++ b/backend/tests/test_drivers_proxy.py
@@ -1,0 +1,30 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+import app.main as main
+import httpx
+
+app = main.create_app()
+
+
+class DummyClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, url, params=None):
+        assert url == "https://ergast.com/api/f1/drivers/"
+        assert params == {"limit": "1"}
+        return httpx.Response(200, json={"MRData": {"DriverTable": []}})
+
+
+@pytest.mark.asyncio
+async def test_drivers_proxy(monkeypatch):
+    monkeypatch.setattr(main, "httpx", type("m", (), {"AsyncClient": DummyClient}))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url='http://test') as ac:
+        res = await ac.get('/ergast/f1/drivers/?limit=1')
+        assert res.status_code == 200
+        assert "MRData" in res.json()


### PR DESCRIPTION
## Summary
- implement `/ergast` proxy endpoint
- add `test_drivers_proxy` to verify drivers endpoint

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1bc3b60c83319b4682930c0cb6d6