### PR TITLE
Add JOLPICA_BASE_URL docs and stack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # F1 Weekend Insights
 
-Development environment:
+## Running the Stack
 
 ```bash
 docker-compose up --build
@@ -12,6 +12,15 @@ Postgres and Redis. The compose configuration references the Dockerfiles in the
 
 For convenience, you can start the stack using `run-stack.bat` on Windows or `./run-stack.sh` on Linux/macOS.
 These scripts build and start the containers, wait a few seconds and then open http://localhost:3000 in your browser.
+The backend API is reachable at http://localhost:8000 when the compose stack is running.
+
+## Configuration
+
+The backend proxies requests to the public [jolpica](https://jolpi.ca) API. The
+upstream base URL can be configured through the `JOLPICA_BASE_URL` environment
+variable which defaults to `https://api.jolpi.ca` if not specified.  Each route
+exposed by the backend mirrors the corresponding jolpica endpoint.  For example,
+`/series` on the backend simply forwards to `${JOLPICA_BASE_URL}/series`.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- document how to run the stack
- explain proxy API behaviour and `JOLPICA_BASE_URL`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1bc4aa2483318e7fcc42c8372094