### PR TITLE
Add apply button to trigger lap stats

### DIFF
--- a/frontend/src/app/page.module.css
+++ b/frontend/src/app/page.module.css
@@ -189,6 +189,20 @@ a.secondary {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
+.controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.select {
+  flex: 1;
+}
+
+.button {
+  padding: 8px 16px;
+}
+
 @media (prefers-color-scheme: dark) {
   .chartCard {
     box-shadow: 0 2px 4px rgba(255, 255, 255, 0.05);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useState } from 'react';
 import styles from './page.module.css';
 import { useApi } from '../lib/useApi';
 
@@ -11,11 +12,32 @@ const PositionsWaterfall = dynamic(() => import('../components/charts/PositionsW
 const TrackEvolution = dynamic(() => import('../components/charts/TrackEvolution'), { ssr: false });
 
 export default function Home() {
-  const { data: laps } = useApi<any[]>('laps', '/api/laps');
+  const [sessionType, setSessionType] = useState('race');
+  const [path, setPath] = useState('');
+  const { data: laps } = useApi<any[]>('laps', path, { enabled: Boolean(path) });
   const sample = laps || [];
+
+  const handleApply = () => {
+    setPath(`/api/laps?session=${encodeURIComponent(sessionType)}`);
+  };
+
   return (
     <main className={styles.main}>
       <h1 className={styles.title}>Race Insights</h1>
+      <div className={styles.controls}>
+        <select
+          className={styles.select}
+          value={sessionType}
+          onChange={(e) => setSessionType(e.target.value)}
+        >
+          <option value="fp1">FP1</option>
+          <option value="fp2">FP2</option>
+          <option value="fp3">FP3</option>
+          <option value="qualifying">Qualifying</option>
+          <option value="race">Race</option>
+        </select>
+        <button className={styles.button} onClick={handleApply}>Apply</button>
+      </div>
       <div className={styles.grid}>
         <div className={styles.chartCard}>
           <LapTimeLine data={sample} />


### PR DESCRIPTION
## Summary
- add a session selector with an Apply button on the home page
- style the new controls

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a1c44c088833182f744eb47144928