### PR TITLE
Add Ergast proxy API routes

### DIFF
--- a/frontend/src/app/api/constructors/route.ts
+++ b/frontend/src/app/api/constructors/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+
+function lastTenYears(): number[] {
+  const current = new Date().getFullYear();
+  const years: number[] = [];
+  for (let y = current; y >= current - 9; y--) {
+    years.push(y);
+  }
+  return years;
+}
+
+async function fetchConstructors(year: number) {
+  const res = await fetch(`https://ergast.com/api/f1/${year}/constructors.json?limit=1000`);
+  if (!res.ok) throw new Error(`Failed fetching ${year} constructors`);
+  const data = await res.json();
+  return data?.MRData?.ConstructorTable?.Constructors || [];
+}
+
+export async function GET() {
+  const years = lastTenYears();
+  const map: Record<string, any> = {};
+  try {
+    for (const y of years) {
+      const constructors = await fetchConstructors(y);
+      for (const c of constructors) {
+        if (!map[c.constructorId]) {
+          map[c.constructorId] = c; // keep latest name by processing years desc
+        }
+      }
+    }
+    return NextResponse.json(Object.values(map));
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/drivers/route.ts
+++ b/frontend/src/app/api/drivers/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+
+function lastTenYears(): number[] {
+  const current = new Date().getFullYear();
+  const years: number[] = [];
+  for (let y = current; y >= current - 9; y--) {
+    years.push(y);
+  }
+  return years;
+}
+
+async function fetchDrivers(year: number) {
+  const res = await fetch(`https://ergast.com/api/f1/${year}/drivers.json?limit=1000`);
+  if (!res.ok) throw new Error(`Failed fetching ${year} drivers`);
+  const data = await res.json();
+  return data?.MRData?.DriverTable?.Drivers || [];
+}
+
+export async function GET() {
+  const years = lastTenYears();
+  const map: Record<string, any> = {};
+  try {
+    for (const y of years) {
+      const drivers = await fetchDrivers(y);
+      for (const d of drivers) {
+        if (!map[d.driverId]) {
+          map[d.driverId] = d;
+        }
+      }
+    }
+    return NextResponse.json(Object.values(map));
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/seasons/route.ts
+++ b/frontend/src/app/api/seasons/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+
+function lastTenYears(): number[] {
+  const current = new Date().getFullYear();
+  const years: number[] = [];
+  for (let y = current; y >= current - 9; y--) {
+    years.push(y);
+  }
+  return years;
+}
+
+export async function GET() {
+  const years = lastTenYears();
+  try {
+    const res = await fetch('https://ergast.com/api/f1/seasons.json?limit=1000');
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Failed to fetch seasons' }, { status: 502 });
+    }
+    const data = await res.json();
+    const all: number[] = data?.MRData?.SeasonTable?.Seasons?.map((s: any) => parseInt(s.season)) || [];
+    const filtered = all.filter((s) => years.includes(s)).sort((a, b) => b - a);
+    return NextResponse.json(filtered);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add seasons proxy route filtered to the last decade
- add drivers proxy route aggregating drivers from the last decade
- add constructors proxy route keeping newest constructor names

## Testing
- `npm install --prefix frontend`
- `npm test --prefix frontend`
- `pip install -r backend/requirements.txt`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_687a1c72003c8331926a0a49f4087a8b