### PR TITLE
Add pagination to API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,22 @@
 from fastapi import FastAPI
+from typing import Sequence, TypeVar, Optional
 from contextlib import asynccontextmanager
 
 from .database import init_db
 from .models import Event, Session, Lap
 from .fastf1_adapter import get_session
+
+T = TypeVar("T")
+
+
+def paginate(
+    items: Sequence[T], limit: Optional[int] = None, offset: int = 0
+) -> list[T]:
+    """Return a slice of *items* using ``limit`` and ``offset`` parameters."""
+    sliced = list(items)[offset:]
+    if limit is not None:
+        sliced = sliced[:limit]
+    return sliced
 
 
 @asynccontextmanager
@@ -16,36 +29,50 @@ def create_app() -> FastAPI:
     app = FastAPI(title="F1 Weekend Insights", lifespan=lifespan)
 
     @app.get("/series")
-    async def get_series():
-        return ["F1"]
+    async def get_series(limit: int | None = None, offset: int = 0):
+        data = ["F1"]
+        return paginate(data, limit, offset)
 
     @app.get("/seasons")
-    async def get_seasons(series: str = "F1"):
-        return list(range(2025, 2017, -1))
+    async def get_seasons(
+        series: str = "F1", limit: int | None = None, offset: int = 0
+    ):
+        seasons = list(range(2025, 2017, -1))
+        return paginate(seasons, limit, offset)
 
     @app.get("/events/{season}")
-    async def get_events(season: int):
-        return []
+    async def get_events(season: int, limit: int | None = None, offset: int = 0):
+        events: list[Event] = []
+        return paginate(events, limit, offset)
 
     @app.get("/sessions/{event_id}")
-    async def get_sessions(event_id: int):
-        return []
+    async def get_sessions(event_id: int, limit: int | None = None, offset: int = 0):
+        sessions: list[Session] = []
+        return paginate(sessions, limit, offset)
 
     @app.get("/weekend/{session_id}/laps")
-    async def get_laps(session_id: int):
-        return []
+    async def get_laps(session_id: int, limit: int | None = None, offset: int = 0):
+        laps: list[Lap] = []
+        return paginate(laps, limit, offset)
 
     @app.get("/weekend/{session_id}/stints")
-    async def get_stints(session_id: int):
-        return []
+    async def get_stints(session_id: int, limit: int | None = None, offset: int = 0):
+        stints: list[dict] = []
+        return paginate(stints, limit, offset)
 
     @app.get("/summary/drivers")
-    async def summary_drivers(season: int = None, event: int = None):
-        return []
+    async def summary_drivers(
+        season: int = None, event: int = None, limit: int | None = None, offset: int = 0
+    ):
+        drivers: list[dict] = []
+        return paginate(drivers, limit, offset)
 
     @app.get("/summary/constructors")
-    async def summary_constructors(season: int = None, event: int = None):
-        return []
+    async def summary_constructors(
+        season: int = None, event: int = None, limit: int | None = None, offset: int = 0
+    ):
+        constructors: list[dict] = []
+        return paginate(constructors, limit, offset)
 
     @app.post("/compare")
     async def compare():

--- a/backend/tests/test_basic.py
+++ b/backend/tests/test_basic.py
@@ -6,13 +6,35 @@ from asgi_lifespan import LifespanManager
 
 app = main.create_app()
 
+
 @pytest.mark.asyncio
 async def test_series():
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url='http://test') as ac:
-        res = await ac.get('/series')
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        res = await ac.get("/series")
         assert res.status_code == 200
-        assert res.json() == ['F1']
+        assert res.json() == ["F1"]
+
+        res = await ac.get("/series", params={"limit": 1, "offset": 0})
+        assert res.status_code == 200
+        assert res.json() == ["F1"]
+
+        res = await ac.get("/series", params={"offset": 1})
+        assert res.status_code == 200
+        assert res.json() == []
+
+
+@pytest.mark.asyncio
+async def test_seasons_pagination():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        res = await ac.get("/seasons", params={"limit": 2})
+        assert res.status_code == 200
+        assert res.json() == [2025, 2024]
+
+        res = await ac.get("/seasons", params={"offset": 6})
+        assert res.status_code == 200
+        assert res.json() == [2019, 2018]
 
 
 def test_get_session_cache(monkeypatch):
@@ -20,22 +42,24 @@ def test_get_session_cache(monkeypatch):
 
     class DummySession:
         def load(self):
-            calls.append('load')
+            calls.append("load")
 
     def fake_get_session(season, gp, session):
         calls.append((season, gp, session))
         return DummySession()
 
-    monkeypatch.setattr(fastf1_adapter, 'fastf1', type('m', (), {'get_session': fake_get_session}))
+    monkeypatch.setattr(
+        fastf1_adapter, "fastf1", type("m", (), {"get_session": fake_get_session})
+    )
 
     fastf1_adapter.get_session.cache_clear()
 
-    sess1 = fastf1_adapter.get_session(2024, 'Bahrain', 'FP1')
-    sess2 = fastf1_adapter.get_session(2024, 'Bahrain', 'FP1')
+    sess1 = fastf1_adapter.get_session(2024, "Bahrain", "FP1")
+    sess2 = fastf1_adapter.get_session(2024, "Bahrain", "FP1")
 
     assert sess1 is sess2
-    assert calls.count('load') == 1
-    assert calls.count((2024, 'Bahrain', 'FP1')) == 1
+    assert calls.count("load") == 1
+    assert calls.count((2024, "Bahrain", "FP1")) == 1
 
 
 @pytest.mark.asyncio
@@ -45,14 +69,14 @@ async def test_lifespan_calls_init_db(monkeypatch):
     async def fake_init_db():
         called.append(True)
 
-    monkeypatch.setattr(main, 'init_db', fake_init_db)
+    monkeypatch.setattr(main, "init_db", fake_init_db)
 
     app = main.create_app()
 
     transport = ASGITransport(app=app)
     async with LifespanManager(app):
-        async with AsyncClient(transport=transport, base_url='http://test') as ac:
-            res = await ac.get('/series')
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            res = await ac.get("/series")
             assert res.status_code == 200
 
-    assert called, 'init_db should be called during lifespan startup'
+    assert called, "init_db should be called during lifespan startup"


### PR DESCRIPTION
## Summary
- enable `limit` and `offset` parameters on local API endpoints
- test pagination on `/series` and `/seasons`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1c7377c4833192793fdb518a8de7