### PR TITLE
Update README with proxy and jolpica info

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,23 @@ Postgres and Redis. The compose configuration references the Dockerfiles in the
 For convenience, you can start the stack using `run-stack.bat` on Windows or `./run-stack.sh` on Linux/macOS.
 These scripts build and start the containers, wait a few seconds and then open http://localhost:3000 in your browser.
 The backend API is reachable at http://localhost:8000 when the compose stack is running.
+The frontend issues requests using `/api` paths. If `NEXT_PUBLIC_API_BASE_URL` is
+set, Next.js rewrites those paths to `${NEXT_PUBLIC_API_BASE_URL}/api/*`, letting
+the frontend stay agnostic of the backend's host.
 
 ## Configuration
 
-The backend proxies requests to the public [jolpica](https://jolpi.ca) API. The
-upstream base URL can be configured through the `JOLPICA_BASE_URL` environment
-variable which defaults to `https://api.jolpi.ca` if not specified.  Each route
-exposed by the backend mirrors the corresponding jolpica endpoint.  For example,
-`/series` on the backend simply forwards to `${JOLPICA_BASE_URL}/series`.
+The backend proxies requests to the [jolpica-f1](https://github.com/jolpica/jolpica-f1)
+API. The upstream base URL is configured through the `JOLPICA_BASE_URL`
+environment variable which defaults to `https://api.jolpi.ca` if not specified.
+The public service only retains the last ten seasons. If you need data older
+than that, run your own jolpica-f1 instance and set `JOLPICA_BASE_URL` to its
+address.
+
+Every backend route mirrors its jolpica counterpart. For example,
+`/api/series` simply forwards to `${JOLPICA_BASE_URL}/series`. Routes under
+`/api/driver`, `/api/events` and others follow the same pattern so your
+frontend can use the jolpica-f1 API documentation as a reference.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- clarify how `/api` requests are proxied through NEXT_PUBLIC_API_BASE_URL
- describe JOLPICA_BASE_URL and the 10-season limit
- document that backend routes mirror jolpica-f1

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1c75c32883318dae423578251e54