### PR TITLE
Remove duplicate block in driver page

### DIFF
--- a/frontend/src/app/drivers/page.tsx
+++ b/frontend/src/app/drivers/page.tsx
@@ -51,30 +51,6 @@ export default function DriversPage() {
         </select>
       </div>
       <DriverSummaryCards summary={summary || []} />
-  const { data } = useApi<any[]>('drivers', '/api/drivers');
-  const drivers = data || [];
-  const [selected, setSelected] = useState('');
-  return (
-    <main className={styles.main}>
-      <h1 className={styles.title}>Drivers</h1>
-      <select
-        className={styles.select}
-        value={selected}
-        onChange={(e) => setSelected(e.target.value)}
-      >
-        <option value="">Select Driver</option>
-        {drivers.map((d) => {
-          const name =
-            d.name ||
-            d.fullName ||
-            `${d.givenName ?? ''} ${d.familyName ?? ''}`.trim();
-          return (
-            <option key={d.id ?? d.code ?? name} value={d.id}>
-              {name}
-            </option>
-          );
-        })}
-      </select>
       <div className={styles.grid}>
         {drivers.map((driver, i) => (
           <Link


### PR DESCRIPTION
## Summary
- remove duplicate hook and return block in `DriversPage`

## Testing
- `npm run build` *(fails: Type '{ params: { id: string; }; }' does not satisfy the constraint 'PageProps')*

------
https://chatgpt.com/codex/tasks/task_e_687a455c3cc8833184fb63db15b709fc