### PR TITLE
Fix duplicate imports and DB helper

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,4 @@
 from fastapi import FastAPI, Query, Request, Response, Depends
-from fastapi import Depends, FastAPI, Query, Request, Response
 from contextlib import asynccontextmanager
 import httpx
 from sqlalchemy import select, func
@@ -7,11 +6,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .database import init_db, async_session
 from .models import Event, Session, Lap
-
-async def get_db() -> AsyncSession:
-    async with async_session() as session:
-        yield session
-
 
 async def get_db() -> AsyncSession:
     async with async_session() as session:


### PR DESCRIPTION
## Summary
- remove duplicate `fastapi` import in backend
- clean up extra `get_db` function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a49f5a644833193a857c4c0ca8e57