### PR TITLE
Remove unused Babel config

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ['next/babel'],
-};


### PR DESCRIPTION
## Summary
- drop `frontend/babel.config.js`

## Testing
- `npm run build` *(fails: Failed to load SWC binary)*

------
https://chatgpt.com/codex/tasks/task_e_687a4a0c8e048331837bf0e1af0e0c06