### PR TITLE
Fix Jest config for JSX tests

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,14 @@
-module.exports = {
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
   },
-};
+}
+
+module.exports = createJestConfig(customJestConfig)


### PR DESCRIPTION
## Summary
- configure Jest via `next/jest`

## Testing
- `pytest backend/tests -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b318a759c833183126325643983c5