### PR TITLE
Fix unclosed CSS block in drivers module

### DIFF
--- a/frontend/src/app/drivers/drivers.module.css
+++ b/frontend/src/app/drivers/drivers.module.css
@@ -27,6 +27,5 @@
 
 .select {
   min-width: 200px;
-.select {
   max-width: 300px;
 }


### PR DESCRIPTION
## Summary
- fix bad `.select` block in `drivers.module.css`

## Testing
- `npm test` within `frontend`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b417961b48331a38a4f93bbfcc18f