### PR TITLE
Fix type for dynamic driver page

### DIFF
--- a/frontend/src/app/drivers/[id]/page.tsx
+++ b/frontend/src/app/drivers/[id]/page.tsx
@@ -3,11 +3,7 @@ import { useState } from 'react';
 import { useApi } from '../../../lib/useApi';
 import DriverCard from '../../../components/DriverCard';
 import DriverSeasonsTable from '../../../components/DriverSeasonsTable';
-import type { PageProps } from 'next';
-
-type Props = PageProps<{ id: string }>;
-
-export default function DriverPage({ params }: Props) {
+export default function DriverPage({ params }: { params: { id: string } }) {
   const id = params.id;
   const { data: driver } = useApi<any>(`driver-${id}`, `/api/driver/${id}`);
   const { data: seasons } = useApi<any[]>(`driver-${id}-seasons`, `/api/driver/${id}/seasons`);


### PR DESCRIPTION
## Summary
- simplify the DriverPage type declaration

## Testing
- `npm test --prefix frontend`
- `python -m pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_687b4b791e908331bac19023a5cb6d9b