### PR TITLE
Update session fetch path

### DIFF
--- a/frontend/__tests__/home-page.test.js
+++ b/frontend/__tests__/home-page.test.js
@@ -1,0 +1,72 @@
+beforeAll(() => { global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }; });
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import HomePage from '../src/app/page';
+
+function setupFetch() {
+  global.fetch = jest.fn((url) => {
+    if (url === '/api/seasons') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([2025]),
+      });
+    }
+    if (url === '/api/events/2025') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([{ id: 1, name: 'Bahrain GP' }]),
+      });
+    }
+    if (url === '/api/sessions/1') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([{ id: 10, name: 'Race' }]),
+      });
+    }
+    if (url === '/api/weekend/10/laps') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    }
+    return Promise.reject(new Error('Unknown URL ' + url));
+  });
+}
+
+function renderPage() {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <HomePage />
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('apply fetches laps from selected session', async () => {
+  setupFetch();
+  renderPage();
+  // wait for seasons to load
+  await screen.findByRole('option', { name: '2025' });
+  const selects = screen.getAllByRole('combobox');
+  const seasonSelect = selects[0];
+  const raceSelect = selects[1];
+  const sessionSelect = selects[2];
+
+  fireEvent.change(seasonSelect, { target: { value: '2025' } });
+  await screen.findByRole('option', { name: 'Bahrain GP' });
+  fireEvent.change(raceSelect, { target: { value: '1' } });
+  await screen.findByRole('option', { name: 'Race' });
+  fireEvent.change(sessionSelect, { target: { value: '10' } });
+
+  fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+  await waitFor(() =>
+    global.fetch.mock.calls.some((c) => c[0] === '/api/weekend/10/laps')
+  );
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
   const { data: seasons } = useApi<number[]>('seasons', '/api/seasons');
   const [season, setSeason] = useState('');
   const [race, setRace] = useState('');
-  const [session, setSession] = useState('');
+  const [sessionId, setSessionId] = useState('');
   const [path, setPath] = useState('');
 
   const { data: races } = useApi<any[]>(
@@ -35,16 +35,16 @@ export default function Home() {
 
   useEffect(() => {
     setRace('');
-    setSession('');
+    setSessionId('');
   }, [season]);
 
   useEffect(() => {
-    setSession('');
+    setSessionId('');
   }, [race]);
 
   const handleApply = () => {
-    if (session) {
-      setPath(`/api/weekend/${session}/laps`);
+    if (sessionId) {
+      setPath(`/api/weekend/${sessionId}/laps`);
     }
   };
 
@@ -79,8 +79,8 @@ export default function Home() {
         </select>
         <select
           className={styles.select}
-          value={session}
-          onChange={(e) => setSession(e.target.value)}
+          value={sessionId}
+          onChange={(e) => setSessionId(e.target.value)}
           disabled={!race}
         >
           <option value="">Session</option>


### PR DESCRIPTION
## Summary
- rename `session` state to `sessionId`
- fetch laps from `/api/weekend/${sessionId}/laps`
- add a test verifying Apply uses sessionId in the URL

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bc707fa948331ba270d5210a54ed8