### PR TITLE
Fix driver page param type

### DIFF
--- a/frontend/src/app/drivers/[id]/page.tsx
+++ b/frontend/src/app/drivers/[id]/page.tsx
@@ -1,6 +1,6 @@
 import DriverPageClient from './Client';
 
-export default async function DriverPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
+export default function DriverPage({ params }: { params: { id: string } }) {
+  const { id } = params;
   return <DriverPageClient id={id} />;
 }


### PR DESCRIPTION
## Summary
- correctly type `params` for driver page
- simplify driver page component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bc9e9cc4c83319a98911321ffa6df