### PR TITLE
Add basic chart components and tests

### DIFF
--- a/frontend/__tests__/charts.test.js
+++ b/frontend/__tests__/charts.test.js
@@ -1,0 +1,24 @@
+beforeAll(() => { global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }; });
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import LapTimeLine from '../src/components/charts/LapTimeLine';
+import TyreStintBar from '../src/components/charts/TyreStintBar';
+import StrategyGantt from '../src/components/charts/StrategyGantt';
+import PositionsWaterfall from '../src/components/charts/PositionsWaterfall';
+import TrackEvolution from '../src/components/charts/TrackEvolution';
+
+test('charts render with sample data', () => {
+  const sample = [
+    { lap: 1, driver: 'HAM', time: 90 },
+    { lap: 1, driver: 'VER', time: 91 },
+    { lap: 2, driver: 'HAM', time: 89 },
+    { lap: 2, driver: 'VER', time: 90 },
+  ];
+
+  expect(render(<LapTimeLine data={sample} />).container.querySelector('.recharts-responsive-container')).toBeInTheDocument();
+  expect(render(<TyreStintBar data={sample} />).container.querySelector('.recharts-responsive-container')).toBeInTheDocument();
+  expect(render(<StrategyGantt data={sample} />).container.querySelector('.recharts-responsive-container')).toBeInTheDocument();
+  expect(render(<PositionsWaterfall data={sample} />).container.querySelector('.recharts-responsive-container')).toBeInTheDocument();
+  expect(render(<TrackEvolution data={sample} />).container.querySelector('.recharts-responsive-container')).toBeInTheDocument();
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -100,13 +100,13 @@ export default function Home() {
           <TyreStintBar data={sample} />
         </div>
         <div className={styles.chartCard}>
-          <StrategyGantt />
+          <StrategyGantt data={sample} />
         </div>
         <div className={styles.chartCard}>
-          <PositionsWaterfall />
+          <PositionsWaterfall data={sample} />
         </div>
         <div className={styles.chartCard}>
-          <TrackEvolution />
+          <TrackEvolution data={sample} />
         </div>
       </div>
     </main>

--- a/frontend/src/components/charts/PositionsWaterfall.tsx
+++ b/frontend/src/components/charts/PositionsWaterfall.tsx
@@ -1,4 +1,37 @@
 'use client';
-export default function PositionsWaterfall() {
-  return <div>Waterfall Placeholder</div>;
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+
+interface LapData {
+  lap: number;
+  driver: string;
+  time: number;
+}
+
+export default function PositionsWaterfall({ data }: { data: LapData[] }) {
+  if (!data || data.length === 0) return null;
+
+  const driver = data[0].driver;
+  const laps: Record<number, LapData[]> = {};
+  data.forEach((d) => {
+    if (!laps[d.lap]) laps[d.lap] = [];
+    laps[d.lap].push(d);
+  });
+  const chart = Object.keys(laps)
+    .map((lap) => {
+      const entries = laps[Number(lap)].sort((a, b) => a.time - b.time);
+      const pos = entries.findIndex((l) => l.driver === driver) + 1;
+      return { lap: Number(lap), position: pos };
+    })
+    .sort((a, b) => a.lap - b.lap);
+
+  return (
+    <ResponsiveContainer width="100%" height={300} data-testid="waterfall-chart">
+      <LineChart data={chart} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <XAxis dataKey="lap" />
+        <YAxis reversed allowDecimals={false} />
+        <Tooltip />
+        <Line type="stepAfter" dataKey="position" stroke="#8884d8" />
+      </LineChart>
+    </ResponsiveContainer>
+  );
 }

--- a/frontend/src/components/charts/StrategyGantt.tsx
+++ b/frontend/src/components/charts/StrategyGantt.tsx
@@ -1,4 +1,27 @@
 'use client';
-export default function StrategyGantt() {
-  return <div>Gantt Placeholder</div>;
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+
+interface LapData {
+  lap: number;
+  driver: string;
+}
+
+export default function StrategyGantt({ data }: { data: LapData[] }) {
+  if (!data || data.length === 0) return null;
+  const lapsByDriver: Record<string, number> = {};
+  data.forEach((d) => {
+    lapsByDriver[d.driver] = Math.max(lapsByDriver[d.driver] || 0, d.lap);
+  });
+  const chartData = Object.entries(lapsByDriver).map(([driver, laps]) => ({ driver, laps }));
+
+  return (
+    <ResponsiveContainer width="100%" height={50 * chartData.length} data-testid="gantt-chart">
+      <BarChart data={chartData} layout="vertical" margin={{ top: 10, right: 30, left: 40, bottom: 0 }}>
+        <XAxis type="number" allowDecimals={false} />
+        <YAxis type="category" dataKey="driver" />
+        <Tooltip />
+        <Bar dataKey="laps" fill="#82ca9d" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
 }

--- a/frontend/src/components/charts/TrackEvolution.tsx
+++ b/frontend/src/components/charts/TrackEvolution.tsx
@@ -1,4 +1,32 @@
 'use client';
-export default function TrackEvolution() {
-  return <div>Track Evolution Placeholder</div>;
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+
+interface LapData {
+  lap: number;
+  driver: string;
+  time: number;
+}
+
+export default function TrackEvolution({ data }: { data: LapData[] }) {
+  if (!data || data.length === 0) return null;
+  const grouped: Record<number, { sum: number; count: number }> = {};
+  data.forEach(({ lap, time }) => {
+    if (!grouped[lap]) grouped[lap] = { sum: 0, count: 0 };
+    grouped[lap].sum += time;
+    grouped[lap].count += 1;
+  });
+  const chartData = Object.keys(grouped)
+    .map((lap) => ({ lap: Number(lap), time: grouped[lap].sum / grouped[lap].count }))
+    .sort((a, b) => a.lap - b.lap);
+
+  return (
+    <ResponsiveContainer width="100%" height={300} data-testid="evolution-chart">
+      <LineChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+        <XAxis dataKey="lap" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="time" stroke="#ff7300" />
+      </LineChart>
+    </ResponsiveContainer>
+  );
 }


### PR DESCRIPTION
## Summary
- implement initial logic for chart components
- pass lap data to charts in home page
- add chart rendering unit tests

## Testing
- `npm install`
- `npm test`
- `pip install -r backend/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687bca96ecfc8331b4dccfc3a6de756e