### PR TITLE
Add frontend tests for dropdowns and driver page

### DIFF
--- a/frontend/__tests__/driver-page.test.js
+++ b/frontend/__tests__/driver-page.test.js
@@ -1,0 +1,66 @@
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DriverPage from '../src/app/drivers/[id]/page';
+
+function setupFetch({ driver, seasons = {}, races = {} }) {
+  global.fetch = jest.fn((url) => {
+    if (url === `/api/driver/${driver.id}`) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(driver) });
+    }
+    if (url === `/api/driver/${driver.id}/seasons`) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(Object.values(seasons)) });
+    }
+    const raceMatch = url.match(new RegExp(`/api/driver/${driver.id}/season/(\\d+)/races`));
+    if (raceMatch) {
+      const year = raceMatch[1];
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(races[year] || []) });
+    }
+    return Promise.reject(new Error('Unknown URL ' + url));
+  });
+}
+
+function renderPage(id) {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <DriverPage params={{ id }} />
+    </QueryClientProvider>
+  );
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('driver summary updates when season row is selected', async () => {
+  const driver = { id: 'ham', givenName: 'Lewis', familyName: 'Hamilton', team: 'Mercedes' };
+  setupFetch({
+    driver,
+    seasons: {
+      2023: { year: 2023, team: 'Mercedes' },
+      2022: { year: 2022, team: 'McLaren' },
+    },
+    races: {
+      2022: [],
+      2023: [],
+    },
+  });
+  renderPage('ham');
+  await screen.findByText('Lewis Hamilton');
+  expect(screen.getAllByText('Mercedes')[0]).toBeInTheDocument();
+  fireEvent.click(screen.getByText('2022'));
+  await waitFor(() => {
+    const elements = screen.getAllByText('McLaren');
+    expect(elements.length).toBeGreaterThan(0);
+  });
+  expect(global.fetch.mock.calls.some((c) => c[0] === '/api/driver/ham/season/2022/races')).toBe(true);
+});

--- a/frontend/__tests__/home-page.test.js
+++ b/frontend/__tests__/home-page.test.js
@@ -1,34 +1,40 @@
-beforeAll(() => { global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }; });
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import HomePage from '../src/app/page';
 
-function setupFetch() {
+function setupFetch({ seasons = [], races = {}, sessions = {}, laps = {} } = {}) {
   global.fetch = jest.fn((url) => {
     if (url === '/api/seasons') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(seasons) });
+    }
+    const eventsMatch = url.match(/^\/api\/events\/(\d+)/);
+    if (eventsMatch) {
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve([2025]),
+        json: () => Promise.resolve(races[eventsMatch[1]] || []),
       });
     }
-    if (url === '/api/events/2025') {
+    const sessionsMatch = url.match(/^\/api\/sessions\/(\d+)/);
+    if (sessionsMatch) {
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve([{ id: 1, name: 'Bahrain GP' }]),
+        json: () => Promise.resolve(sessions[sessionsMatch[1]] || []),
       });
     }
-    if (url === '/api/sessions/1') {
+    const lapsMatch = url.match(/^\/api\/weekend\/(\d+)\/laps/);
+    if (lapsMatch) {
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve([{ id: 10, name: 'Race' }]),
-      });
-    }
-    if (url === '/api/weekend/10/laps') {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve([]),
+        json: () => Promise.resolve(laps[lapsMatch[1]] || []),
       });
     }
     return Promise.reject(new Error('Unknown URL ' + url));
@@ -48,25 +54,69 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
-test('apply fetches laps from selected session', async () => {
-  setupFetch();
+test('seasons dropdown populates from API', async () => {
+  setupFetch({ seasons: [2025, 2024] });
   renderPage();
-  // wait for seasons to load
+  const seasonSelect = screen.getAllByRole('combobox')[0];
   await screen.findByRole('option', { name: '2025' });
-  const selects = screen.getAllByRole('combobox');
-  const seasonSelect = selects[0];
-  const raceSelect = selects[1];
-  const sessionSelect = selects[2];
+  const opts = within(seasonSelect).getAllByRole('option').map((o) => o.textContent);
+  expect(opts).toEqual(['Season', '2025', '2024']);
+});
 
+test('races filter based on selected season', async () => {
+  setupFetch({
+    seasons: [2025, 2024],
+    races: {
+      2025: [{ id: 1, name: 'Bahrain GP' }],
+      2024: [{ id: 2, name: 'Imola GP' }],
+    },
+  });
+  renderPage();
+  const [seasonSelect, raceSelect] = screen.getAllByRole('combobox');
+  fireEvent.change(seasonSelect, { target: { value: '2025' } });
+  await waitFor(() =>
+    global.fetch.mock.calls.some((c) => c[0] === '/api/events/2025')
+  );
+  fireEvent.change(seasonSelect, { target: { value: '2024' } });
+  await waitFor(() =>
+    global.fetch.mock.calls.some((c) => c[0] === '/api/events/2024')
+  );
+  expect(raceSelect.value).toBe('');
+});
+
+test('sessions load when race is selected', async () => {
+  setupFetch({
+    seasons: [2025],
+    races: { 2025: [{ id: 1, name: 'Bahrain GP' }] },
+    sessions: { 1: [{ id: 10, name: 'Race' }] },
+  });
+  renderPage();
+  const [seasonSelect, raceSelect, sessionSelect] = screen.getAllByRole('combobox');
+  fireEvent.change(seasonSelect, { target: { value: '2025' } });
+  await waitFor(() =>
+    global.fetch.mock.calls.some((c) => c[0] === '/api/events/2025')
+  );
+  fireEvent.change(raceSelect, { target: { value: '1' } });
+  await waitFor(() =>
+    global.fetch.mock.calls.some((c) => c[0] === '/api/sessions/1')
+  );
+});
+
+test('apply fetches laps from selected session', async () => {
+  setupFetch({
+    seasons: [2025],
+    races: { 2025: [{ id: 1, name: 'Bahrain GP' }] },
+    sessions: { 1: [{ id: 10, name: 'Race' }] },
+    laps: { 10: [] },
+  });
+  renderPage();
+  await screen.findByRole('option', { name: '2025' });
+  const [seasonSelect, raceSelect, sessionSelect] = screen.getAllByRole('combobox');
   fireEvent.change(seasonSelect, { target: { value: '2025' } });
   await screen.findByRole('option', { name: 'Bahrain GP' });
   fireEvent.change(raceSelect, { target: { value: '1' } });
   await screen.findByRole('option', { name: 'Race' });
   fireEvent.change(sessionSelect, { target: { value: '10' } });
-
   fireEvent.click(screen.getByRole('button', { name: /apply/i }));
-
-  await waitFor(() =>
-    global.fetch.mock.calls.some((c) => c[0] === '/api/weekend/10/laps')
-  );
+  await waitFor(() => global.fetch.mock.calls.some((c) => c[0] === '/api/weekend/10/laps'));
 });


### PR DESCRIPTION
## Summary
- extend homepage tests with checks for seasons, races, sessions and laps
- add driver page test for season selection behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bcc2d97b4833194041c731a2abed3