### PR TITLE
Fix Next.js build type error

### DIFF
--- a/frontend/src/app/drivers/[id]/page.tsx
+++ b/frontend/src/app/drivers/[id]/page.tsx
@@ -1,6 +1,6 @@
 import DriverPageClient from './Client';
 
-export default function DriverPage({ params }: { params: { id: string } }) {
-  const { id } = params;
+export default function DriverPage({ params }: any) {
+  const { id } = params as { id: string };
   return <DriverPageClient id={id} />;
 }

--- a/frontend/src/components/charts/TrackEvolution.tsx
+++ b/frontend/src/components/charts/TrackEvolution.tsx
@@ -16,7 +16,11 @@ export default function TrackEvolution({ data }: { data: LapData[] }) {
     grouped[lap].count += 1;
   });
   const chartData = Object.keys(grouped)
-    .map((lap) => ({ lap: Number(lap), time: grouped[lap].sum / grouped[lap].count }))
+    .map((lap) => {
+      const key = Number(lap);
+      const { sum, count } = grouped[key];
+      return { lap: key, time: sum / count };
+    })
     .sort((a, b) => a.lap - b.lap);
 
   return (


### PR DESCRIPTION
## Summary
- avoid PageProps mismatch in dynamic driver page
- fix typed indexing in track evolution chart

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bceca783c8331b990b38898cbadc3