### PR TITLE
Enable automatic DB seeding and configure API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ These scripts build and start the containers, wait a few seconds and then open h
 The backend API is reachable at http://localhost:8000 when the compose stack is running.
 The frontend issues requests using `/api` paths. If `NEXT_PUBLIC_API_BASE_URL` is
 set, Next.js rewrites those paths to `${NEXT_PUBLIC_API_BASE_URL}/api/*`, letting
-the frontend stay agnostic of the backend's host.
+the frontend stay agnostic of the backend's host. The provided `docker-compose.yml`
+defines this variable so the frontend automatically points at the backend
+container.
 
 ## Configuration
 

--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -1,4 +1,5 @@
 from app.main import create_app
 
 
-app = create_app()
+# Ensure FastF1 data is ingested when the application starts
+app = create_app(sync_on_startup=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
   frontend:
     build: ./frontend
     command: npm run dev
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: http://api:8000
     volumes:
       - ./frontend:/app
       - /app/node_modules


### PR DESCRIPTION
## Summary
- seed FastF1 data when the ASGI app boots
- route frontend API calls to backend container
- document environment variable in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c71a8a0488331ac53d61788cbb4e1